### PR TITLE
fix: always run shutdown even there is an error

### DIFF
--- a/app/application_test.go
+++ b/app/application_test.go
@@ -115,6 +115,35 @@ func TestApplication(t *testing.T) {
 		}
 	})
 
+	t.Run("should call Shutdown if a hook from OnRun returns an error", func(t *testing.T) {
+		hook1Called := 0
+		hook2Called := 0
+
+		lc := app.New()
+		lc.OnRun(func(_ context.Context) error {
+			hook1Called++
+			return errors.New("run error")
+		})
+
+		lc.OnShutdown(func(ctx context.Context) error {
+			hook2Called++
+			return nil
+		})
+
+		err := lc.Run(context.Background())
+		if fmt.Sprintf("%v", err) != "run error" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if hook1Called != 1 {
+			t.Errorf("Expected hook1 is called but got %d", hook1Called)
+		}
+
+		if hook2Called != 1 {
+			t.Errorf("Expected hook2 is called once but got %d", hook2Called)
+		}
+	})
+
 	t.Run("should run AfterRun hook", func(t *testing.T) {
 		hook1Called := 0
 		doneCh := make(chan struct{})

--- a/plugin/graceful_shutdown.go
+++ b/plugin/graceful_shutdown.go
@@ -17,7 +17,7 @@ func GracefulShutdown() app.Plugin {
 // gracefulShutdownPlugin is a plugin to allow the application to receive SIGTERM signal
 // and shuts down the application gracefully.
 type gracefulShutdownPlugin struct {
-	App *app.Application `inject:"*"`
+	App *app.Application `inject:"app"`
 }
 
 func (s *gracefulShutdownPlugin) Initialize() error {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,7 +3,7 @@ package plugin
 import "github.com/bongnv/sen/app"
 
 type componentPlugin struct {
-	App *app.Application `inject:"*"`
+	App *app.Application `inject:"app"`
 
 	name      string
 	component any


### PR DESCRIPTION
This will help to make sure that there is no loss in graceful shutdown. The app should wait for all shutdowns are fully executed before returning.